### PR TITLE
Fix: Resolve race condition in AuraGameSDK DBManager integration

### DIFF
--- a/AuraGameSDK.js
+++ b/AuraGameSDK.js
@@ -6,7 +6,7 @@
 const AuraGameSDK = {
     _gameId: null,
     _canvasElement: null,
-    _dbManager: window.dbManager, // Assuming dbManager is globally available
+    get _dbManager() { return window.dbManager; }, // Assuming dbManager is globally available
 
     /**
      * Initializes the SDK for a specific game.


### PR DESCRIPTION
The AuraGameSDK was initializing its internal `_dbManager` reference by directly assigning `window.dbManager` at the time the SDK script was parsed. At this point, `window.dbManager.db` (the actual IndexedDB connection) was null because `DBManager.init()` (an asynchronous operation) had not yet completed.

This commit changes the `_dbManager` property in `AuraGameSDK.js` to a getter function: `get _dbManager() { return window.dbManager; }`.

This ensures that `AuraGameSDK` always accesses the most current version of the `window.dbManager` instance, which will have its `.db` property correctly initialized after `DBManager.init()` completes. This resolves the race condition, allowing game progress saving and leaderboard score submissions to function correctly.