### PR TITLE
fix: Correct Monaco Editor loading and DBManager API usage for Notes App

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,9 @@
     <!-- jsmediatags for MP3 metadata extraction -->
     <script src="https://cdn.jsdelivr.net/npm/jsmediatags@3.9.5/dist/jsmediatags.min.js"></script>
 
+    <!-- Monaco Editor Loader -->
+    <script src="https://cdn.jsdelivr.net/npm/monaco-editor@0.44.0/min/vs/loader.js"></script>
+
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
This commit addresses critical issues that prevented the Notes app from initializing and functioning correctly.

Fixes:
1.  **Monaco Editor Loading:**
    *   Added the Monaco Editor loader script (`vs/loader.js`) directly to
        `index.html`'s `<head>`. This ensures `require` and `monaco`
        are globally available before `AuraNotesApp` attempts to use them.
    *   Refactored `_initEditor()` in `AuraOS/notes.js` to use the
        globally available `require` and `monaco` objects, and re-added
        `require.config` for path configuration.

2.  **DBManager API for Directories:**
    *   Investigated `DBManager.js` and found no explicit `createDirectory` or
        `getDirectory` methods.
    *   Refactored `_ensureNotesDirectory()` in `AuraOS/notes.js` to:
        *   Use `dbManager.loadFile()` to check for a directory marker.
        *   Use `dbManager.saveFile({ path: '/Notes/', type: 'folder' }, null)`
            to create the `/Notes/` directory marker if it doesn't exist.
    *   Verified that `dbManager.listFiles('/Notes/')` is used correctly for
        retrieving notes.

Summary of the full Notes App refactor included in previous commits on this conceptual branch:
*   Replaced monolithic Notes app logic in `index.html` with `AuraOS/notes.js`.
*   Created `AuraNotesApp` class for self-contained application logic.
*   Dynamically constructed UI (sidebar, editor area) using AuraOS CSS variables.
*   Integrated Monaco Editor for text editing, with dynamic theme updates.
*   Implemented file system logic for notes in `/Notes/` via `dbManager`:
    *   Loading and displaying note lists.
    *   Creating new notes with unique naming.
    *   Auto-saving notes with debouncing and title update in list.
    *   Deleting notes with confirmation.
    *   Real-time search/filtering of notes.
*   Ensured proper event handling and cleanup on window close.
*   Integrated the new app into `initializeAppLogic`.