### PR TITLE
Fix: Correct game launch failures in Game Center

### DIFF
--- a/AuraBreaker.js
+++ b/AuraBreaker.js
@@ -275,4 +275,4 @@ function AuraBreakerGame(canvas) {
 }
 
 // Make AuraBreakerGame globally accessible if needed by Game Center to instantiate it.
-// window.AuraBreakerGame = AuraBreakerGame;
+window.AuraBreakerGame = AuraBreakerGame;

--- a/AuraInvaders.js
+++ b/AuraInvaders.js
@@ -404,3 +404,5 @@ function AuraInvadersGame(canvas) {
   };
 
 } // End of AuraInvadersGame constructor
+
+window.AuraInvadersGame = AuraInvadersGame;

--- a/AuraOS/AuraPong.js
+++ b/AuraOS/AuraPong.js
@@ -461,3 +461,5 @@ AuraPongGame.prototype.drawParticles = function() {
     }
   }
 };
+
+window.AuraPongGame = AuraPongGame;

--- a/AuraOS/AuraSnake.js
+++ b/AuraOS/AuraSnake.js
@@ -379,4 +379,4 @@ function AuraSnakeGame(canvas) {
 }
 
 // If AuraSnakeGame needs to be globally accessible for instantiation by Game Center:
-// window.AuraSnakeGame = AuraSnakeGame;
+window.AuraSnakeGame = AuraSnakeGame;

--- a/AuraOS/AuraTetris.js
+++ b/AuraOS/AuraTetris.js
@@ -138,8 +138,6 @@ function AuraTetrisGame(canvas) {
         return true;
     }
 
-    generateNewPiece();
-
     function drawBlock(x,y,c,iS=false){if(iS){ctx.globalAlpha=0.3;ctx.strokeStyle=c;ctx.lineWidth=2;ctx.strokeRect(x+BLOCK_PADDING,y+BLOCK_PADDING,BLOCK_SIZE-2*BLOCK_PADDING,BLOCK_SIZE-2*BLOCK_PADDING);ctx.globalAlpha=1.0;return;}
 ctx.globalAlpha=0.6;ctx.fillStyle=c;ctx.fillRect(x+BLOCK_PADDING,y+BLOCK_PADDING,BLOCK_SIZE-2*BLOCK_PADDING,BLOCK_SIZE-2*BLOCK_PADDING);
 ctx.globalAlpha=0.3;ctx.fillStyle='rgba(255,255,255,0.5)';const gI=BLOCK_PADDING*2;ctx.fillRect(x+gI,y+gI,BLOCK_SIZE-2*gI,BLOCK_SIZE-2*gI);


### PR DESCRIPTION
This commit addresses issues preventing AuraPong, AuraInvaders, and AuraTetris from launching correctly.

The following changes were implemented:

1.  **Global Scope for Game Constructors:**
    - `AuraOS/AuraPong.js`: Added `window.AuraPongGame = AuraPongGame;` to make the constructor globally accessible.
    - `AuraInvaders.js`: Added `window.AuraInvadersGame = AuraInvadersGame;` to make the constructor globally accessible.
    - `AuraOS/AuraSnake.js`: Uncommented `window.AuraSnakeGame = AuraSnakeGame;` to ensure global accessibility.
    - `AuraBreaker.js`: Uncommented `window.AuraBreakerGame = AuraBreakerGame;` to ensure global accessibility. (Note: `AuraOS/AuraTetris.js` already had its constructor globally exposed).

2.  **Refactor AuraTetris Constructor:**
    - `AuraOS/AuraTetris.js`: Removed the direct call to `generateNewPiece()` from the `AuraTetrisGame` constructor. This logic is correctly handled by the `start()` method, preventing premature game termination.

These changes ensure a consistent and robust initialization pattern across the games, allowing them to be reliably instantiated and started from the Game Center.